### PR TITLE
Use c2rust implementation when targeting Wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,7 @@ once_cell = { version = "1.5.2", default-features = false, features=["std"], opt
 once_cell = { version = "1.5.2", default-features = false, features=["std"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_env = ""))'.dependencies]
-web-sys = { version = "0.3.37", default-features = false, features = ["Crypto", "Window"] }
+web-sys = { version = "0.3.37", default-features = false, features = ["Crypto", "Window"], optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3.8", default-features = false, features = ["ntsecapi", "wtypesbase"] }
@@ -347,7 +347,7 @@ slow_tests = []
 std = ["alloc"]
 test_logging = []
 wasm32_c = []
-# wasm32_unknown_unknown_js = ["web-sys"]
+wasm32_unknown_unknown_js = ["web-sys"]
 size_optimized = []
 
 # XXX: debug = false because of https://github.com/rust-lang/rust/issues/34122

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ extern crate alloc;
 #[macro_use]
 mod debug;
 
-#[cfg(target_os="xous")]
+#[cfg(any(target_arch="wasm32", target_os="xous"))]
 #[macro_use]
 mod prefixed;
 
@@ -109,11 +109,11 @@ pub mod io;
 
 mod cpu;
 pub mod digest;
-#[cfg(all(target_os="xous",not(target_arch="x86_64")))]
+#[cfg(any(target_arch="wasm32", all(target_os="xous",not(target_arch="x86_64"))))]
 pub mod ec_17;
-#[cfg(all(target_os="xous",not(target_arch="x86_64")))]
+#[cfg(any(target_arch="wasm32", all(target_os="xous",not(target_arch="x86_64"))))]
 pub use ec_17 as ec;
-#[cfg(not(all(target_os="xous",not(target_arch="x86_64"))))]
+#[cfg(not(any(target_arch="wasm32", all(target_os="xous",not(target_arch="x86_64")))))]
 mod ec;
 mod endian;
 pub mod error;
@@ -145,7 +145,7 @@ mod sealed {
     pub trait Sealed {}
 }
 
-#[cfg(target_os="xous")]
+#[cfg(any(target_arch="wasm32", target_os="xous"))]
 mod c2rust {
     pub mod aes_nohw;
     pub mod montgomery;
@@ -167,12 +167,12 @@ mod xous_rand;
 #[cfg(target_os="xous")]
 pub mod xous_test;
 
-#[cfg(target_os="xous")]
+#[cfg(any(target_arch="wasm32", target_os="xous"))]
 type c_char = i8;
-#[cfg(target_os="xous")]
+#[cfg(any(target_arch="wasm32", target_os="xous"))]
 type c_uint = u32;
-#[cfg(target_os="xous")]
 #[export_name = "__assert_fail"]
+#[cfg(any(target_arch="wasm32", target_os="xous"))]
 pub unsafe extern "C" fn __assert_fail(
     __assertion: *const c_char,
     __file: *const c_char,
@@ -181,4 +181,3 @@ pub unsafe extern "C" fn __assert_fail(
 ) -> ! {
     panic!("assert fail");
 }
-

--- a/src/limb.rs
+++ b/src/limb.rs
@@ -331,7 +331,7 @@ pub fn fold_5_bit_windows<R, I: FnOnce(Window) -> R, F: Fn(R, Window) -> R>(
         })
 }
 
-#[cfg(target_os="xous")]
+#[cfg(any(target_arch = "wasm32", target_os = "xous"))]
 #[inline]
 pub(crate) fn limbs_add_assign_mod(a: &mut [Limb], b: &[Limb], m: &[Limb]) {
     debug_assert_eq!(a.len(), m.len());

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -264,6 +264,7 @@ mod sysrand_chunk {
 }
 
 #[cfg(all(
+    feature = "wasm32_unknown_unknown_js",
     target_arch = "wasm32",
     target_vendor = "unknown",
     target_os = "unknown",
@@ -288,6 +289,21 @@ mod sysrand_chunk {
             .map_err(|_| error::Unspecified)?;
 
         Ok(dest.len())
+    }
+}
+
+#[cfg(all(
+    not(feature = "wasm32_unknown_unknown_js"),
+    target_arch = "wasm32",
+    target_vendor = "unknown",
+    target_os = "unknown",
+    target_env = "",
+))]
+mod sysrand_chunk {
+    use crate::error;
+
+    pub fn chunk(mut _dest: &mut [u8]) -> Result<usize, error::Unspecified> {
+        unimplemented!()
     }
 }
 


### PR DESCRIPTION
I'm working in an environment that only allows targeting `wasm32-unknown-unknown`.

I recently added a dependency that depended on `ring` (or `openssl`) and despite other people saying it worked for them, I wasn't able to get either of these to compile to Wasm because of the non-Rust dependencies.

`ring` seemed the more likely to work, but then I learned that for most Wasm targets (including the one I'm targeting) the ABI isn't compatible with the C ABI, so while linking with C can appear to work it can result in hidden memory corruption.

https://github.com/rust-lang/rust/issues/83788 and https://github.com/rustwasm/team/issues/291 go into some detail on that.

In hoping to avoid all of that while still using a well-vetted implementation I came across [Fully Oxidizing `ring`](https://www.bunniestudios.com/blog/?p=6521) and it seemed like the perfect solution. I'm at least going to try using it until a better solution comes along.

After some back and forth I'm pleased to have landed on this minimal set of changes that enables me to use `ring` when targeting `wasm32-unknown-unknown`.

I'd be very grateful if you could take a look and let me know what you think.